### PR TITLE
Bumping FFplay_jll version to 7 and fixing play call

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,6 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [compat]
 Configurations = "0.17"
 DataDeps = "0.7"
-FFplay_jll = "4"
+FFplay_jll = "7"
 REPL = "1"
 julia = "1.10"

--- a/src/play.jl
+++ b/src/play.jl
@@ -1,18 +1,17 @@
 function play(file::AbstractString; loop = false)
     @assert isfile(file)
-    ffplay() do exe
-        args = ["-nodisp", "-v", "0", "-autoexit"]
-        if loop
-            append!(args, ["-loop", "9999"])
-        end
-        @debug "Running play command $(Cmd(vcat(exe, args, file)))"
-        run(
-            addenv(
-                Cmd(vcat(exe, args, file)),
-                "ALSA_CONFIG_PATH" => "/usr/share/alsa/alsa.conf",
-                "ALSA_PLUGIN_DIR" => "/usr/lib/alsa-lib/",
-            );
-            wait = false,
-        )
+    args = ["-nodisp", "-v", "0", "-autoexit"]
+    if loop
+        append!(args, ["-loop", "9999"])
     end
+    @debug "Running play command $(Cmd(vcat(exe, args, file)))"
+
+    run(
+        addenv(
+            `$(ffplay()) $args $file`,
+            "ALSA_CONFIG_PATH" => "/usr/share/alsa/alsa.conf",
+            "ALSA_PLUGIN_DIR" => "/usr/lib/alsa-lib/",
+        ),
+        wait = false,
+    )
 end


### PR DESCRIPTION
Updating the FFply_jll to version 7 and using the non-deprecated way of calling it fixed the playback problems (for me) on mac os.

potentially fixes #3 